### PR TITLE
クラウドランサービスのグループ化とレイアウト変更

### DIFF
--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -6,7 +6,12 @@ on:
       - test
   pull_request:
     branches:
-      - main
+      - test
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'edited'
+      - 'reopened'
   workflow_dispatch:
 
 concurrency:
@@ -35,8 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: 'true'
+        #  with:
+        #  submodules: 'true'
 
       - name: Google Cloud auth
         id: auth

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -1,17 +1,12 @@
-name: Deploy Cloud Functions (test)
+name: Deploy Cloud Run (test)
 
 on:
-  # push:
-  #   branches:
-  #     - test
-  # pull_request:
-  #   branches:
-  #     - test
-  #   types:
-  #     - 'opened'
-  #     - 'synchronize'
-  #     - 'edited'
-  #     - 'reopened'
+  push:
+    branches:
+      - test
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -25,44 +20,47 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      function_name: ${{ steps.set_name.outputs.function_name }}
+      service_name: ${{ steps.set_name.outputs.service_name }}
     steps:
-      - name: Set function name
+      - name: Set service name
         id: set_name
         run: |
-          # if [ -n "${{ github.event.pull_request.number }}" ]; then
-          #   echo "function_name=my-cfapps-portal-test${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          # else
-            echo "function_name=my-cfapps-portal-test" >> $GITHUB_OUTPUT
-          # fi
+          echo "service_name=my-cfapps-portal-test" >> $GITHUB_OUTPUT
 
   deploy:
     needs: prepare
-    uses: yananob/cloud-functions-common/.github/workflows/deploy-cloud-functions.yaml@main
-    with:
-      function_name: ${{ needs.prepare.outputs.function_name }}
-      service_account_name: 'cloud-run-functions-deployer'
-      wip_pool_name: 'github-actions-pool'
-      wip_provider_name: 'github-provider'
-      runtime: php82
-      secrets_config: |-
-        SECRET_KEYS
-      # gcs_source_dir: ./public/
-      # gcs_bucket_name: my-cfapps-portal-static
-      # gcs_bucket_path: test
-      # disable_gcs_cache: true
-      deploy_http_trigger: true
-      deploy_event_trigger: false
-      http_max_instance_count: 1
-      memory: '256M'
-      http_timeout: '5m'
-      event_timeout: '540s'
-      environment_variables: |-
-        APP_ENV=test
-    secrets:
-      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      GCP_PROJECT_NUMBER: ${{ secrets.GCP_PROJECT_NUMBER }}
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Google Cloud auth
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'cloud-run-functions-deployer@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
+
+      - name: Deploy to Cloud Run
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          service: ${{ needs.prepare.outputs.service_name }}
+          region: ${{ secrets.GCP_REGION }}
+          source: .
+          flags: --memory=256Mi
+          env_vars: |-
+            GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
+            GCP_REGION=${{ secrets.GCP_REGION }}
+            GITHUB_PAT=${{ secrets.GH_PAT }}
+            GITHUB_OWNER=${{ secrets.GH_OWNER }}
+            APP_ENV=test
+          secrets: |-
+            GCLOUD_SERVICE_ACCOUNT=GCLOUD_SERVICE_ACCOUNT:latest
 
   comment:
     needs: [prepare, deploy]
@@ -80,4 +78,4 @@ jobs:
           submodules: 'true'
       - name: Add comment to PR
         run: |
-          gh pr comment $PR_NUMBER --body "Deployed to url https://${{ secrets.GCP_REGION }}-${{ secrets.GCP_PROJECT_ID }}.cloudfunctions.net/${{ needs.prepare.outputs.function_name }} [skip ci]"
+          gh pr comment $PR_NUMBER --body "Deployed to url ${{ needs.deploy.outputs.url }} [skip ci]"

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCloudRunServices } from "@/lib/gcp-client";
 import { getAllReposInfo } from "@/lib/github-client";
+import { ServiceGroup } from "@/lib/types";
 
 export async function GET() {
   try {
@@ -9,22 +10,45 @@ export async function GET() {
       getAllReposInfo(),
     ]);
 
-    const combinedData = services.map((service) => {
-      const repoInfo = repoMap.get(service.name);
-      return {
-        id: service.name,
+    const groupsMap = new Map<string, ServiceGroup>();
+
+    for (const service of services) {
+      let baseName = service.name;
+      let type: "main" | "test" | "event" = "main";
+
+      if (service.name.endsWith("-test")) {
+        baseName = service.name.replace(/-test$/, "");
+        type = "test";
+      } else if (service.name.endsWith("-event")) {
+        baseName = service.name.replace(/-event$/, "");
+        type = "event";
+      }
+
+      let group = groupsMap.get(baseName);
+      if (!group) {
+        const repoInfo = repoMap.get(baseName);
+        group = {
+          baseName,
+          repoUrl: repoInfo?.repoUrl,
+          issueUrl: repoInfo?.issueUrl,
+        };
+        groupsMap.set(baseName, group);
+      }
+
+      group[type] = {
         url: service.url,
         logUrl: service.logUrl,
-        repoUrl: repoInfo?.repoUrl,
-        issueUrl: repoInfo?.issueUrl,
       };
-    });
+    }
+
+    const combinedData = Array.from(groupsMap.values()).sort((a, b) =>
+      a.baseName.localeCompare(b.baseName)
+    );
 
     return NextResponse.json(combinedData);
   } catch (error: any) {
     console.error("API error:", error);
 
-    // エラーメッセージをクライアントに返す（デバッグ用だが、指示書にはプライベートポータルとあるので許容）
     const errorMessage = error instanceof Error ? error.message : "Internal Server Error";
 
     return NextResponse.json(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,17 +4,10 @@ import { useState, useEffect, useMemo } from "react";
 import { Search, Loader2, RefreshCw, AlertCircle } from "lucide-react";
 import { ServiceCard } from "@/components/ServiceCard";
 import { cn } from "@/lib/utils";
-
-interface ServiceData {
-  id: string;
-  url: string;
-  repoUrl?: string;
-  issueUrl?: string;
-  logUrl: string;
-}
+import { ServiceGroup } from "@/lib/types";
 
 export default function Dashboard() {
-  const [services, setServices] = useState<ServiceData[]>([]);
+  const [serviceGroups, setServiceGroups] = useState<ServiceGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -28,7 +21,7 @@ export default function Dashboard() {
       const data = await response.json();
 
       if (response.ok) {
-        setServices(data);
+        setServiceGroups(data);
         setLastUpdated(new Date());
       } else {
         setError(data.error || "Failed to fetch services");
@@ -45,11 +38,11 @@ export default function Dashboard() {
     fetchServices();
   }, []);
 
-  const filteredServices = useMemo(() => {
-    return services.filter((service) =>
-      service.id.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredGroups = useMemo(() => {
+    return serviceGroups.filter((group) =>
+      group.baseName.toLowerCase().includes(searchQuery.toLowerCase())
     );
-  }, [services, searchQuery]);
+  }, [serviceGroups, searchQuery]);
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl">
@@ -104,27 +97,28 @@ export default function Dashboard() {
         </div>
       )}
 
-      {loading && services.length === 0 ? (
+      {loading && serviceGroups.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20">
           <Loader2 className="w-10 h-10 text-blue-500 animate-spin mb-4" />
           <p className="text-slate-500">Loading services...</p>
         </div>
       ) : (
         <>
-          {!error && filteredServices.length === 0 ? (
+          {!error && filteredGroups.length === 0 ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg p-12 text-center">
               <p className="text-slate-500">No services found.</p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {filteredServices.map((service) => (
+            <div className="flex flex-col gap-4">
+              {filteredGroups.map((group) => (
                 <ServiceCard
-                  key={service.id}
-                  name={service.id}
-                  url={service.url}
-                  repoUrl={service.repoUrl}
-                  issueUrl={service.issueUrl}
-                  logUrl={service.logUrl}
+                  key={group.baseName}
+                  baseName={group.baseName}
+                  main={group.main}
+                  test={group.test}
+                  event={group.event}
+                  repoUrl={group.repoUrl}
+                  issueUrl={group.issueUrl}
                 />
               ))}
             </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,79 +1,145 @@
 import React from "react";
-import { Github, MessageSquare, ListTodo, Globe } from "lucide-react";
+import { Github, MessageSquare, ListTodo, Globe, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ServiceInstance } from "@/lib/types";
 
 interface ServiceCardProps {
-  name: string;
-  url: string;
+  baseName: string;
+  main?: ServiceInstance;
+  test?: ServiceInstance;
+  event?: ServiceInstance;
   repoUrl?: string;
   issueUrl?: string;
-  logUrl: string;
 }
 
+const InstanceLinks: React.FC<{
+  label: string;
+  instance?: ServiceInstance;
+  colorClass: string;
+  textColorClass: string;
+}> = ({ label, instance, colorClass, textColorClass }) => {
+  if (!instance) {
+    return (
+      <div className="flex flex-col gap-1 opacity-30 grayscale">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">{label}</span>
+        <div className="flex gap-2">
+          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent">
+            <Globe className="w-3.5 h-3.5" /> App
+          </div>
+          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent">
+            <ListTodo className="w-3.5 h-3.5" /> Log
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className={cn("text-[10px] font-bold uppercase tracking-wider", textColorClass)}>
+        {label}
+      </span>
+      <div className="flex gap-2">
+        <a
+          href={instance.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white rounded transition-colors shadow-sm",
+            colorClass
+          )}
+        >
+          <Globe className="w-3.5 h-3.5" />
+          <span>App</span>
+          <ExternalLink className="w-3 h-3 opacity-50" />
+        </a>
+        <a
+          href={instance.logUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-slate-700 bg-white border border-slate-200 hover:bg-slate-50 dark:text-slate-200 dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 rounded transition-colors shadow-sm"
+        >
+          <ListTodo className="w-3.5 h-3.5 text-slate-500" />
+          <span>Log</span>
+          <ExternalLink className="w-3 h-3 opacity-30" />
+        </a>
+      </div>
+    </div>
+  );
+};
+
 export const ServiceCard: React.FC<ServiceCardProps> = ({
-  name,
-  url,
+  baseName,
+  main,
+  test,
+  event,
   repoUrl,
   issueUrl,
-  logUrl,
 }) => {
   return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow">
-      <div className="p-5">
-        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4 truncate" title={name}>
-          {name}
-        </h3>
-        <div className="grid grid-cols-2 gap-2">
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
-          >
-            <Globe className="w-4 h-4" />
-            <span>App</span>
-          </a>
-          <a
-            href={logUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-slate-700 hover:bg-slate-800 rounded-md transition-colors"
-          >
-            <ListTodo className="w-4 h-4" />
-            <span>Log</span>
-          </a>
-          {repoUrl ? (
-            <a
-              href={repoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 dark:text-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 rounded-md transition-colors"
-            >
-              <Github className="w-4 h-4" />
-              <span>Repo</span>
-            </a>
-          ) : (
-            <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-slate-400 bg-slate-50 dark:text-slate-600 dark:bg-slate-900 rounded-md cursor-not-allowed">
-              <Github className="w-4 h-4" />
-              <span>Repo</span>
-            </div>
-          )}
-          {issueUrl ? (
-            <a
-              href={issueUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 dark:text-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 rounded-md transition-colors"
-            >
-              <MessageSquare className="w-4 h-4" />
-              <span>Issue</span>
-            </a>
-          ) : (
-            <div className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-slate-400 bg-slate-50 dark:text-slate-600 dark:bg-slate-900 rounded-md cursor-not-allowed">
-              <MessageSquare className="w-4 h-4" />
-              <span>Issue</span>
-            </div>
-          )}
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg shadow-sm hover:shadow-md transition-all overflow-hidden">
+      <div className="flex flex-col md:flex-row md:items-center p-4 md:p-5 gap-6">
+        {/* Name and Repo Links */}
+        <div className="flex-1 min-w-0 md:max-w-[250px]">
+          <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100 truncate mb-3" title={baseName}>
+            {baseName}
+          </h3>
+          <div className="flex gap-3">
+            {repoUrl ? (
+              <a
+                href={repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs font-medium text-slate-600 hover:text-blue-600 dark:text-slate-400 dark:hover:text-blue-400 transition-colors"
+              >
+                <Github className="w-4 h-4" />
+                <span>Repo</span>
+              </a>
+            ) : (
+              <span className="flex items-center gap-1.5 text-xs font-medium text-slate-300 dark:text-slate-600 cursor-not-allowed">
+                <Github className="w-4 h-4" />
+                <span>Repo</span>
+              </span>
+            )}
+            {issueUrl ? (
+              <a
+                href={issueUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs font-medium text-slate-600 hover:text-blue-600 dark:text-slate-400 dark:hover:text-blue-400 transition-colors"
+              >
+                <MessageSquare className="w-4 h-4" />
+                <span>Issues</span>
+              </a>
+            ) : (
+              <span className="flex items-center gap-1.5 text-xs font-medium text-slate-300 dark:text-slate-600 cursor-not-allowed">
+                <MessageSquare className="w-4 h-4" />
+                <span>Issues</span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Instances */}
+        <div className="flex flex-wrap md:flex-nowrap gap-6 md:gap-10 flex-1">
+          <InstanceLinks
+            label="本番環境"
+            instance={main}
+            colorClass="bg-blue-600 hover:bg-blue-700"
+            textColorClass="text-blue-600"
+          />
+          <InstanceLinks
+            label="テスト環境"
+            instance={test}
+            colorClass="bg-emerald-600 hover:bg-emerald-700"
+            textColorClass="text-emerald-600"
+          />
+          <InstanceLinks
+            label="イベントトリガー"
+            instance={event}
+            colorClass="bg-amber-600 hover:bg-amber-700"
+            textColorClass="text-amber-600"
+          />
         </div>
       </div>
     </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,13 @@
+export interface ServiceInstance {
+  url: string;
+  logUrl: string;
+}
+
+export interface ServiceGroup {
+  baseName: string;
+  main?: ServiceInstance;
+  test?: ServiceInstance;
+  event?: ServiceInstance;
+  repoUrl?: string;
+  issueUrl?: string;
+}


### PR DESCRIPTION
ユーザーの要望に基づき、`-test` や `-event` が付くサービスを一つの機能としてグループ化し、1行全体を使って表示するようにUIとロジックを刷新しました。

主な変更点:
1. **API (`src/app/api/services/route.ts`)**:
   - Cloud Run サービスを `baseName` ごとにまとめ、`main`, `test`, `event` の各プロパティに振り分けるように変更。
   - GitHub リポジトリ情報の取得も `baseName` を使用するように修正。
2. **コンポーネント (`src/components/ServiceCard.tsx`)**:
   - 1行全体を使用する横長レイアウトに刷新。
   - 本番環境、テスト環境、イベントトリガーのそれぞれの App/Log リンクを表示。
   - 存在しない環境はグレーアウトして表示。
3. **ページ (`src/app/page.tsx`)**:
   - グリッド表示からリスト表示（`flex-col`）に変更。
4. **型定義 (`src/lib/types.ts`)**:
   - 複数のファイルで重複していた型定義を1か所に集約。


Fixes #6

---
*PR created automatically by Jules for task [12659578610545641575](https://jules.google.com/task/12659578610545641575) started by @yananob*