### PR TITLE
Cloud Run サービスのグループ化ロジック改善と UI 更新

### DIFF
--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -22,9 +22,6 @@ export async function GET() {
       } else if (service.name.endsWith("-test")) {
         baseName = service.name.replace(/-test$/, "");
         type = "test";
-      } else if (service.name.endsWith("_test")) {
-        baseName = service.name.replace(/_test$/, "");
-        type = "test";
       } else if (service.name.endsWith("-event")) {
         baseName = service.name.replace(/-event$/, "");
         type = "event";

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -14,10 +14,16 @@ export async function GET() {
 
     for (const service of services) {
       let baseName = service.name;
-      let type: "main" | "test" | "event" = "main";
+      let type: "main" | "test" | "event" | "testEvent" = "main";
 
-      if (service.name.endsWith("-test")) {
+      if (service.name.endsWith("-test-event")) {
+        baseName = service.name.replace(/-test-event$/, "");
+        type = "testEvent";
+      } else if (service.name.endsWith("-test")) {
         baseName = service.name.replace(/-test$/, "");
+        type = "test";
+      } else if (service.name.endsWith("_test")) {
+        baseName = service.name.replace(/_test$/, "");
         type = "test";
       } else if (service.name.endsWith("-event")) {
         baseName = service.name.replace(/-event$/, "");

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -8,6 +8,7 @@ interface ServiceCardProps {
   main?: ServiceInstance;
   test?: ServiceInstance;
   event?: ServiceInstance;
+  testEvent?: ServiceInstance;
   repoUrl?: string;
   issueUrl?: string;
 }
@@ -73,6 +74,7 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
   main,
   test,
   event,
+  testEvent,
   repoUrl,
   issueUrl,
 }) => {
@@ -80,7 +82,7 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
     <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg shadow-sm hover:shadow-md transition-all overflow-hidden">
       <div className="flex flex-col md:flex-row md:items-center p-4 md:p-5 gap-6">
         {/* Name and Repo Links */}
-        <div className="flex-1 min-w-0 md:max-w-[250px]">
+        <div className="flex-1 min-w-0 md:max-w-[200px]">
           <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100 truncate mb-3" title={baseName}>
             {baseName}
           </h3>
@@ -121,7 +123,7 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
         </div>
 
         {/* Instances */}
-        <div className="flex flex-wrap md:flex-nowrap gap-6 md:gap-10 flex-1">
+        <div className="flex flex-wrap md:flex-nowrap gap-6 md:gap-8 flex-1">
           <InstanceLinks
             label="本番環境"
             instance={main}
@@ -135,10 +137,16 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
             textColorClass="text-emerald-600"
           />
           <InstanceLinks
-            label="イベントトリガー"
+            label="イベント"
             instance={event}
             colorClass="bg-amber-600 hover:bg-amber-700"
             textColorClass="text-amber-600"
+          />
+          <InstanceLinks
+            label="イベント(テスト)"
+            instance={testEvent}
+            colorClass="bg-orange-600 hover:bg-orange-700"
+            textColorClass="text-orange-600"
           />
         </div>
       </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ export interface ServiceGroup {
   main?: ServiceInstance;
   test?: ServiceInstance;
   event?: ServiceInstance;
+  testEvent?: ServiceInstance;
   repoUrl?: string;
   issueUrl?: string;
 }


### PR DESCRIPTION
Cloud Run サービスのグループ化ロジックを改善し、特定のサフィックスを持つサービスを適切に統合しました。

### 変更内容:
1.  **API ロジックの修正 (`src/app/api/services/route.ts`):**
    - `-test-event` で終わるサービスを `testEvent` タイプとして識別するようにしました。
    - `_test` で終わるサービスも `-test` と同様に `test` 環境として扱うようにしました。
    - サフィックスの判定順序を最適化し、誤った置換を防ぎました。

2.  **型定義の更新 (`src/lib/types.ts`):**
    - `ServiceGroup` インターフェースに `testEvent` プロパティを追加しました。

3.  **UI の更新 (`src/components/ServiceCard.tsx`):**
    - イベントトリガーのテスト環境を表示するための列を追加しました。
    - 4つの環境（本番、テスト、イベント、イベント(テスト)）が表示されるようになったため、カード内のレイアウト（幅や間隔）を微調整しました。
    - ラベルを簡潔にするため「イベントトリガー」を「イベント」に変更しました。

これらの変更により、テスト用のサービスが一覧に独立して表示されるのを防ぎ、関連するメインサービスの一部として整理して表示されるようになります。

---
*PR created automatically by Jules for task [9594601518978734591](https://jules.google.com/task/9594601518978734591) started by @yananob*