### PR TITLE
ベースイメージをnode24に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
-        "@types/node": "^20",
+        "@types/node": "^24.12.2",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8",
@@ -1379,12 +1379,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -7157,9 +7157,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   },
   "dependencies": {
     "@google-cloud/run": "^1.5.0",
+    "clsx": "^2.1.1",
     "lucide-react": "0.460.0",
     "next": "15.0.3",
     "octokit": "^4.0.2",
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
-    "clsx": "^2.1.1",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@types/node": "^24.12.2",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",


### PR DESCRIPTION
DockerfileのベースイメージをNode.js 24に変更し、あわせてTypeScriptの型定義も更新しました。ビルドおよび型チェックが正常に完了することを確認済みです。

Fixes #8

---
*PR created automatically by Jules for task [3720841166651418447](https://jules.google.com/task/3720841166651418447) started by @yananob*