### PR TITLE
一覧画面のログリンク、レイアウト、フィルタの改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,15 +69,16 @@ export default function Dashboard() {
               onChange={(e) => setSearchQuery(e.target.value)}
               autoCapitalize="none"
               autoCorrect="off"
+              autoComplete="off"
               spellCheck="false"
             />
             {searchQuery && (
               <button
                 onClick={() => setSearchQuery("")}
-                className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 transition-colors z-10"
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-all z-10 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-full"
                 title="Clear search"
               >
-                <X className="w-4 h-4 stroke-[2.5px]" />
+                <X className="w-4 h-4 stroke-[3px]" />
               </button>
             )}
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,10 +74,10 @@ export default function Dashboard() {
             {searchQuery && (
               <button
                 onClick={() => setSearchQuery("")}
-                className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 transition-colors z-10"
                 title="Clear search"
               >
-                <X className="w-4 h-4" />
+                <X className="w-4 h-4 stroke-[2.5px]" />
               </button>
             )}
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Search, Loader2, RefreshCw, AlertCircle } from "lucide-react";
+import { Search, Loader2, RefreshCw, AlertCircle, X } from "lucide-react";
 import { ServiceCard } from "@/components/ServiceCard";
 import { cn } from "@/lib/utils";
 import { ServiceGroup } from "@/lib/types";
@@ -64,10 +64,22 @@ export default function Dashboard() {
             <input
               type="text"
               placeholder="Search services..."
-              className="w-full pl-10 pr-4 py-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+              className="w-full pl-10 pr-10 py-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck="false"
             />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery("")}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                title="Clear search"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
           </div>
           <button
             onClick={fetchServices}
@@ -117,6 +129,7 @@ export default function Dashboard() {
                   main={group.main}
                   test={group.test}
                   event={group.event}
+                  testEvent={group.testEvent}
                   repoUrl={group.repoUrl}
                   issueUrl={group.issueUrl}
                 />

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -21,9 +21,9 @@ const InstanceLinks: React.FC<{
 }> = ({ label, instance, colorClass, textColorClass }) => {
   if (!instance) {
     return (
-      <div className="flex items-center gap-2 opacity-30 grayscale">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 w-[90px] shrink-0 whitespace-nowrap">{label}</span>
-        <div className="flex gap-1.5">
+      <div className="flex items-center gap-3 opacity-30 grayscale flex-nowrap shrink-0">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 min-w-[80px] shrink-0 whitespace-nowrap">{label}</span>
+        <div className="flex gap-1.5 flex-nowrap shrink-0">
           <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
             <Globe className="w-3.5 h-3.5" /> App
           </div>
@@ -36,11 +36,11 @@ const InstanceLinks: React.FC<{
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className={cn("text-[10px] font-bold uppercase tracking-wider w-[90px] shrink-0 whitespace-nowrap", textColorClass)}>
+    <div className="flex items-center gap-3 flex-nowrap shrink-0">
+      <span className={cn("text-[10px] font-bold uppercase tracking-wider min-w-[80px] shrink-0 whitespace-nowrap", textColorClass)}>
         {label}
       </span>
-      <div className="flex gap-1.5">
+      <div className="flex gap-1.5 flex-nowrap shrink-0">
         <a
           href={instance.url}
           target="_blank"
@@ -123,8 +123,8 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
         </div>
 
         {/* Instances */}
-        <div className="flex flex-col gap-4 flex-1">
-          <div className="flex flex-nowrap gap-6 md:gap-8">
+        <div className="flex flex-col gap-5 flex-1 min-w-0">
+          <div className="flex flex-nowrap gap-8 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-slate-200 dark:scrollbar-thumb-slate-800">
             <InstanceLinks
               label="本番環境"
               instance={main}
@@ -138,7 +138,7 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
               textColorClass="text-emerald-600"
             />
           </div>
-          <div className="flex flex-nowrap gap-6 md:gap-8">
+          <div className="flex flex-nowrap gap-8 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-slate-200 dark:scrollbar-thumb-slate-800">
             <InstanceLinks
               label="イベント"
               instance={event}

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -24,10 +24,10 @@ const InstanceLinks: React.FC<{
       <div className="flex flex-col gap-1 opacity-30 grayscale">
         <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">{label}</span>
         <div className="flex gap-2">
-          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent">
+          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
             <Globe className="w-3.5 h-3.5" /> App
           </div>
-          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent">
+          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
             <ListTodo className="w-3.5 h-3.5" /> Log
           </div>
         </div>
@@ -46,7 +46,7 @@ const InstanceLinks: React.FC<{
           target="_blank"
           rel="noopener noreferrer"
           className={cn(
-            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white rounded transition-colors shadow-sm",
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white rounded transition-colors shadow-sm whitespace-nowrap",
             colorClass
           )}
         >
@@ -58,7 +58,7 @@ const InstanceLinks: React.FC<{
           href={instance.logUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-slate-700 bg-white border border-slate-200 hover:bg-slate-50 dark:text-slate-200 dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 rounded transition-colors shadow-sm"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-slate-700 bg-white border border-slate-200 hover:bg-slate-50 dark:text-slate-200 dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 rounded transition-colors shadow-sm whitespace-nowrap"
         >
           <ListTodo className="w-3.5 h-3.5 text-slate-500" />
           <span>Log</span>
@@ -123,31 +123,35 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
         </div>
 
         {/* Instances */}
-        <div className="flex flex-wrap md:flex-nowrap gap-6 md:gap-8 flex-1">
-          <InstanceLinks
-            label="本番環境"
-            instance={main}
-            colorClass="bg-blue-600 hover:bg-blue-700"
-            textColorClass="text-blue-600"
-          />
-          <InstanceLinks
-            label="テスト環境"
-            instance={test}
-            colorClass="bg-emerald-600 hover:bg-emerald-700"
-            textColorClass="text-emerald-600"
-          />
-          <InstanceLinks
-            label="イベント"
-            instance={event}
-            colorClass="bg-amber-600 hover:bg-amber-700"
-            textColorClass="text-amber-600"
-          />
-          <InstanceLinks
-            label="イベント(テスト)"
-            instance={testEvent}
-            colorClass="bg-orange-600 hover:bg-orange-700"
-            textColorClass="text-orange-600"
-          />
+        <div className="flex flex-col gap-4 flex-1">
+          <div className="flex flex-nowrap gap-6 md:gap-8">
+            <InstanceLinks
+              label="本番環境"
+              instance={main}
+              colorClass="bg-blue-600 hover:bg-blue-700"
+              textColorClass="text-blue-600"
+            />
+            <InstanceLinks
+              label="テスト環境"
+              instance={test}
+              colorClass="bg-emerald-600 hover:bg-emerald-700"
+              textColorClass="text-emerald-600"
+            />
+          </div>
+          <div className="flex flex-nowrap gap-6 md:gap-8">
+            <InstanceLinks
+              label="イベント"
+              instance={event}
+              colorClass="bg-amber-600 hover:bg-amber-700"
+              textColorClass="text-amber-600"
+            />
+            <InstanceLinks
+              label="イベント(テスト)"
+              instance={testEvent}
+              colorClass="bg-orange-600 hover:bg-orange-700"
+              textColorClass="text-orange-600"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -21,13 +21,13 @@ const InstanceLinks: React.FC<{
 }> = ({ label, instance, colorClass, textColorClass }) => {
   if (!instance) {
     return (
-      <div className="flex flex-col gap-1 opacity-30 grayscale">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">{label}</span>
-        <div className="flex gap-2">
-          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
+      <div className="flex items-center gap-2 opacity-30 grayscale">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 w-[90px] shrink-0 whitespace-nowrap">{label}</span>
+        <div className="flex gap-1.5">
+          <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
             <Globe className="w-3.5 h-3.5" /> App
           </div>
-          <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
+          <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-400 rounded border border-transparent whitespace-nowrap">
             <ListTodo className="w-3.5 h-3.5" /> Log
           </div>
         </div>
@@ -36,11 +36,11 @@ const InstanceLinks: React.FC<{
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      <span className={cn("text-[10px] font-bold uppercase tracking-wider", textColorClass)}>
+    <div className="flex items-center gap-2">
+      <span className={cn("text-[10px] font-bold uppercase tracking-wider w-[90px] shrink-0 whitespace-nowrap", textColorClass)}>
         {label}
       </span>
-      <div className="flex gap-2">
+      <div className="flex gap-1.5">
         <a
           href={instance.url}
           target="_blank"

--- a/src/lib/gcp-client.ts
+++ b/src/lib/gcp-client.ts
@@ -32,7 +32,7 @@ export async function getCloudRunServices(): Promise<CloudRunService[]> {
     return (services || []).map((service) => {
       const name = service.name?.split("/").pop() || "";
       const url = service.uri || "";
-      const logUrl = `https://console.cloud.google.com/run/detail/${region}/${name}/logs?project=${projectId}`;
+      const logUrl = `https://console.cloud.google.com/run/observability/${region}/${name}/logs?project=${projectId}&supportedpurview=project`;
 
       return {
         name,


### PR DESCRIPTION
ダッシュボード一覧画面において、以下の改善と修正を行いました。

1. ログリンクの修正:
   Google Cloud Consoleのログ表示URLを、指示された `/run/observability/...` 形式に更新しました。

2. レイアウトの改善:
   各サービスのリンクボタンを2行に分割しました。
   - 1行目: HTTPエンドポイント（本番・テスト）
   - 2行目: イベントトリガー（本番・テスト）
   また、ボタンが折り返されないようスタイリングを調整しました。

3. フィルタ機能の改善:
   検索ボックスに「✕」ボタンを追加し、入力を即座にクリアできるようにしました。また、モバイル環境等で英字入力が優先されるよう、`autoCapitalize` 等の属性を設定しました。

4. バグ修正:
   ダッシュボードから `ServiceCard` コンポーネントに `testEvent` プロパティが渡されていなかった問題を修正しました。

Fixes #18

---
*PR created automatically by Jules for task [13363117788902133538](https://jules.google.com/task/13363117788902133538) started by @yananob*