### PR TITLE
PWA登録時の認証エラー修正

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,27 @@
+
+> cloud-run-manager@0.1.0 dev
+> next dev
+
+   ▲ Next.js 15.5.15
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+
+ ✓ Starting...
+ ✓ Ready in 2s
+ ○ Compiling / ...
+ ✓ Compiled / in 9.1s (640 modules)
+ GET / 200 in 10152ms
+ ✓ Compiled in 225ms (257 modules)
+ GET / 200 in 99ms
+ ○ Compiling /apple-icon ...
+ ✓ Compiled /apple-icon in 5.8s (1266 modules)
+API error: Error: GCP_PROJECT_ID is not set
+    at getCloudRunServices (src/lib/gcp-client.ts:23:11)
+    at GET (src/app/api/services/route.ts:9:26)
+  21 |
+  22 |   if (!projectId) {
+> 23 |     throw new Error("GCP_PROJECT_ID is not set");
+     |           ^
+  24 |   }
+  25 |
+  26 |   const client = getClient();

--- a/public/sw.js
+++ b/public/sw.js
@@ -17,7 +17,11 @@ self.addEventListener('install', (event) => {
 
 self.addEventListener('fetch', (event) => {
   // 外部オリジン（GCP APIなど）へのリクエストはキャッシュしない
-  if (!event.request.url.startsWith(self.location.origin)) {
+  // マニフェストファイルは IAP 認証のリダイレクトを伴う可能性があるため Service Worker で扱わない
+  if (
+    !event.request.url.startsWith(self.location.origin) ||
+    event.request.url.endsWith('manifest.webmanifest')
+  ) {
     return;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,6 +37,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
+      <head>
+        <link rel="manifest" href="/manifest.webmanifest" crossOrigin="use-credentials" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 min-h-screen`}
       >


### PR DESCRIPTION
IAP (Identity-Aware Proxy) 環境下で PWA の登録に失敗する問題を解決するための修正を行いました。

### 変更点
- **layout.tsx**: `<link rel="manifest">` タグに `crossOrigin="use-credentials"` を付与して手動で追加しました。これにより、ブラウザがマニフェストを取得する際に IAP 認証用の Cookie を含めるようになります。
- **sw.js**: Service Worker の `fetch` ハンドラにおいて、`manifest.webmanifest` へのリクエストをキャッシュ処理から除外し、直接ネットワークに任せるようにしました。これは、認証リダイレクトが発生した際に Service Worker が `TypeError: Failed to fetch` を投げるのを防ぐためです。

### 検証内容
- `npm run build` および `npm run lint` が正常に完了することを確認しました。
- Playwright を使用して、生成された HTML の `head` 内に `crossorigin="use-credentials"` 属性を持つ `link` タグが存在することを確認しました。

---
*PR created automatically by Jules for task [11125516947167688771](https://jules.google.com/task/11125516947167688771) started by @yananob*