### PR TITLE
Julesへのリンク追加

### DIFF
--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -34,6 +34,7 @@ export async function GET() {
           baseName,
           repoUrl: repoInfo?.repoUrl,
           issueUrl: repoInfo?.issueUrl,
+          julesUrl: repoInfo?.julesUrl,
         };
         groupsMap.set(baseName, group);
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -133,6 +133,7 @@ export default function Dashboard() {
                   testEvent={group.testEvent}
                   repoUrl={group.repoUrl}
                   issueUrl={group.issueUrl}
+                  julesUrl={group.julesUrl}
                 />
               ))}
             </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Github, MessageSquare, ListTodo, Globe, ExternalLink } from "lucide-react";
+import { Github, MessageSquare, ListTodo, Globe, ExternalLink, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ServiceInstance } from "@/lib/types";
 
@@ -11,6 +11,7 @@ interface ServiceCardProps {
   testEvent?: ServiceInstance;
   repoUrl?: string;
   issueUrl?: string;
+  julesUrl?: string;
 }
 
 const InstanceButtons: React.FC<{
@@ -67,6 +68,7 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
   testEvent,
   repoUrl,
   issueUrl,
+  julesUrl,
 }) => {
   return (
     <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg shadow-sm hover:shadow-md transition-all overflow-hidden">
@@ -102,6 +104,19 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
               </a>
             ) : (
               <MessageSquare className="w-4 h-4 sm:w-5 h-5 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
+            )}
+            {julesUrl ? (
+              <a
+                href={julesUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-slate-500 hover:text-blue-600 transition-colors"
+                title="Jules"
+              >
+                <Zap className="w-4 h-4 sm:w-5 h-5" />
+              </a>
+            ) : (
+              <Zap className="w-4 h-4 sm:w-5 h-5 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
             )}
           </div>
         </div>

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -3,6 +3,7 @@ import { Octokit } from "octokit";
 export interface GitHubRepoInfo {
   repoUrl: string;
   issueUrl: string;
+  julesUrl: string;
 }
 
 /**
@@ -35,6 +36,7 @@ export async function getAllReposInfo(): Promise<Map<string, GitHubRepoInfo>> {
       repoMap.set(repo.name, {
         repoUrl: repo.html_url,
         issueUrl: `${repo.html_url}/issues`,
+        julesUrl: `https://jules.google.com/repo/github/${githubOwner}/${repo.name}/`,
       });
     }
     return repoMap;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,4 +11,5 @@ export interface ServiceGroup {
   testEvent?: ServiceInstance;
   repoUrl?: string;
   issueUrl?: string;
+  julesUrl?: string;
 }


### PR DESCRIPTION
各サービスからJulesへ直接アクセスできるようにするため、以下の変更を行いました：

1. `src/lib/types.ts`: `ServiceGroup` インターフェースに `julesUrl` を追加。
2. `src/lib/github-client.ts`: GitHubのリポジトリ情報からJulesのURLを生成するロジックを追加。
   - URL形式: `https://jules.google.com/repo/github/{owner}/{repo}/`
3. `src/app/api/services/route.ts`: APIレスポンスに `julesUrl` を含めるよう修正。
4. `src/components/ServiceCard.tsx`: UIにJulesへのリンク（Zapアイコン）を追加。
5. `src/app/page.tsx`: `ServiceCard` に `julesUrl` プロパティを渡すよう修正。

Playwrightを使用したフロントエンド検証により、リンクが正しく表示され機能することを確認済みです。

Fixes #27

---
*PR created automatically by Jules for task [13841557251601637464](https://jules.google.com/task/13841557251601637464) started by @yananob*