### PR TITLE
Service Workerのキャッシュ管理改善

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cr-manager-cache-v1';
+const CACHE_NAME = 'cr-manager-cache-v2';
 const urlsToCache = [
   '/',
   '/icon.svg',
@@ -7,11 +7,30 @@ const urlsToCache = [
 ];
 
 self.addEventListener('install', (event) => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then((cache) => {
         return cache.addAll(urlsToCache);
       })
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    Promise.all([
+      self.clients.claim(),
+      caches.keys().then((cacheNames) => {
+        return Promise.all(
+          cacheNames.map((cacheName) => {
+            if (cacheName !== CACHE_NAME) {
+              console.log('Deleting old cache:', cacheName);
+              return caches.delete(cacheName);
+            }
+          })
+        );
+      })
+    ])
   );
 });
 
@@ -25,6 +44,28 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // ナビゲーションリクエスト（HTML）は Network First
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          // 正常なレスポンスのみキャッシュを更新
+          if (response && response.status === 200 && response.type === 'basic') {
+            const responseClone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => {
+              cache.put(event.request, responseClone);
+            });
+          }
+          return response;
+        })
+        .catch(() => {
+          return caches.match(event.request);
+        })
+    );
+    return;
+  }
+
+  // それ以外は Cache First
   event.respondWith(
     caches.match(event.request)
       .then((response) => {


### PR DESCRIPTION
デプロイ後に古いレイアウトやコンテンツがキャッシュから表示されてしまう問題を解決するため、Service Worker (`public/sw.js`) の実装を改善しました。

主な変更点:
1.  **Network First 戦略の導入**: トップページ（`/`）などのHTMLリクエストについては、まずネットワークから最新版を取得し、失敗した場合のみキャッシュを使用するようにしました。これにより、オンライン時は常に最新のレイアウトが保証されます。
2.  **キャッシュの自動クリーンアップ**: `activate` イベントリスナーを追加し、`CACHE_NAME`（今回 `v2` に更新）以外の古いバージョンのキャッシュを自動的に削除するようにしました。
3.  **即時適用**: `self.skipWaiting()` と `self.clients.claim()` を使用することで、新しい Service Worker がインストールされた直後に古いものと入れ替わり、制御を開始するようにしました。これにより、ユーザーがページをすべて閉じるのを待たずに更新が適用されます。

---
*PR created automatically by Jules for task [14386615320644836124](https://jules.google.com/task/14386615320644836124) started by @yananob*