### PR TITLE
アプリ一覧をGitHubリポジトリベースに変更

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ export default function Dashboard() {
       <header className="mb-8 flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
-            Cloud Run Services
+            Applications
           </h1>
           {lastUpdated && !error && (
             <p className="text-sm text-slate-500 mt-1">
@@ -63,7 +63,7 @@ export default function Dashboard() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
             <input
               type="text"
-              placeholder="Search services..."
+              placeholder="Search applications..."
               className="w-full pl-10 pr-10 py-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -113,13 +113,13 @@ export default function Dashboard() {
       {loading && serviceGroups.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20">
           <Loader2 className="w-10 h-10 text-blue-500 animate-spin mb-4" />
-          <p className="text-slate-500">Loading services...</p>
+          <p className="text-slate-500">Loading applications...</p>
         </div>
       ) : (
         <>
           {!error && filteredGroups.length === 0 ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg p-12 text-center">
-              <p className="text-slate-500">No services found.</p>
+              <p className="text-slate-500">No applications found.</p>
             </div>
           ) : (
             <div className="flex flex-col gap-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ export default function Dashboard() {
       <header className="mb-8 flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
-            Applications
+            GitHub Apps Manager
           </h1>
           {lastUpdated && !error && (
             <p className="text-sm text-slate-500 mt-1">
@@ -63,7 +63,7 @@ export default function Dashboard() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
             <input
               type="text"
-              placeholder="Search applications..."
+              placeholder="Search apps..."
               className="w-full pl-10 pr-10 py-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -113,13 +113,13 @@ export default function Dashboard() {
       {loading && serviceGroups.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20">
           <Loader2 className="w-10 h-10 text-blue-500 animate-spin mb-4" />
-          <p className="text-slate-500">Loading applications...</p>
+          <p className="text-slate-500">Loading apps...</p>
         </div>
       ) : (
         <>
           {!error && filteredGroups.length === 0 ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg p-12 text-center">
-              <p className="text-slate-500">No applications found.</p>
+              <p className="text-slate-500">No apps found.</p>
             </div>
           ) : (
             <div className="flex flex-col gap-4">

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -33,6 +33,9 @@ export async function getAllReposInfo(): Promise<Map<string, GitHubRepoInfo>> {
 
     const repoMap = new Map<string, GitHubRepoInfo>();
     for (const repo of repos) {
+      // アーカイブされたリポジトリを除外
+      if (repo.archived) continue;
+
       repoMap.set(repo.name, {
         repoUrl: repo.html_url,
         issueUrl: `${repo.html_url}/issues`,

--- a/src/lib/service-utils.ts
+++ b/src/lib/service-utils.ts
@@ -36,17 +36,6 @@ export function groupServices(services: ServiceListItem[], repoMap: Map<string, 
     }
 
     let group = groupsMap.get(baseName);
-    if (!group) {
-      // サービス名がリポジトリ名の一部（接頭辞）である場合や、その逆の場合を考慮してマッチング
-      // 例: repo "oml-empowerd" に対して service "oml" を紐付ける
-      const matchedRepoName = Array.from(groupsMap.keys()).find(repoName =>
-        repoName.startsWith(baseName) || baseName.startsWith(repoName)
-      );
-
-      if (matchedRepoName) {
-        group = groupsMap.get(matchedRepoName);
-      }
-    }
 
     if (!group) {
       // リポジトリが見つからない場合でもグループを作成（Cloud Runのみ存在する場合）

--- a/src/lib/service-utils.ts
+++ b/src/lib/service-utils.ts
@@ -37,6 +37,18 @@ export function groupServices(services: ServiceListItem[], repoMap: Map<string, 
 
     let group = groupsMap.get(baseName);
     if (!group) {
+      // サービス名がリポジトリ名の一部（接頭辞）である場合や、その逆の場合を考慮してマッチング
+      // 例: repo "oml-empowerd" に対して service "oml" を紐付ける
+      const matchedRepoName = Array.from(groupsMap.keys()).find(repoName =>
+        repoName.startsWith(baseName) || baseName.startsWith(repoName)
+      );
+
+      if (matchedRepoName) {
+        group = groupsMap.get(matchedRepoName);
+      }
+    }
+
+    if (!group) {
       // リポジトリが見つからない場合でもグループを作成（Cloud Runのみ存在する場合）
       group = {
         baseName,

--- a/src/lib/service-utils.ts
+++ b/src/lib/service-utils.ts
@@ -9,6 +9,17 @@ export interface ServiceListItem {
 export function groupServices(services: ServiceListItem[], repoMap: Map<string, { repoUrl: string; issueUrl: string; julesUrl: string }>): ServiceGroup[] {
   const groupsMap = new Map<string, ServiceGroup>();
 
+  // 1. GitHubリポジトリをベースに初期グループを作成
+  for (const [name, repoInfo] of repoMap.entries()) {
+    groupsMap.set(name, {
+      baseName: name,
+      repoUrl: repoInfo.repoUrl,
+      issueUrl: repoInfo.issueUrl,
+      julesUrl: repoInfo.julesUrl,
+    });
+  }
+
+  // 2. Cloud Runサービスを各グループに割り当て
   for (const service of services) {
     let baseName = service.name;
     let type: "main" | "test" | "event" | "testEvent" = "main";
@@ -26,12 +37,9 @@ export function groupServices(services: ServiceListItem[], repoMap: Map<string, 
 
     let group = groupsMap.get(baseName);
     if (!group) {
-      const repoInfo = repoMap.get(baseName);
+      // リポジトリが見つからない場合でもグループを作成（Cloud Runのみ存在する場合）
       group = {
         baseName,
-        repoUrl: repoInfo?.repoUrl,
-        issueUrl: repoInfo?.issueUrl,
-        julesUrl: repoInfo?.julesUrl,
       };
       groupsMap.set(baseName, group);
     }

--- a/tests/service-grouping.test.ts
+++ b/tests/service-grouping.test.ts
@@ -33,6 +33,20 @@ describe('groupServices', () => {
     expect(otherGroup?.repoUrl).toBeUndefined()
   })
 
+  it('includes repositories without any associated services', () => {
+    const services: ServiceListItem[] = []
+    const repoMap = new Map([
+      ['only-repo', { repoUrl: 'https://github/only-repo', issueUrl: 'https://github/only-repo/issues', julesUrl: 'https://jules/only-repo' }],
+    ])
+
+    const result = groupServices(services, repoMap)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].baseName).toBe('only-repo')
+    expect(result[0].repoUrl).toBe('https://github/only-repo')
+    expect(result[0].main).toBeUndefined()
+  })
+
   it('sorts groups by base name', () => {
     const services: ServiceListItem[] = [
       { name: 'z-app', url: 'https://z', logUrl: 'https://logs/z' },

--- a/tests/service-grouping.test.ts
+++ b/tests/service-grouping.test.ts
@@ -47,23 +47,6 @@ describe('groupServices', () => {
     expect(result[0].main).toBeUndefined()
   })
 
-  it('matches services with repo names using prefix matching', () => {
-    const services: ServiceListItem[] = [
-      { name: 'oml', url: 'https://oml', logUrl: 'https://logs/oml' },
-      { name: 'oml-test', url: 'https://oml-test', logUrl: 'https://logs/oml-test' },
-    ]
-    const repoMap = new Map([
-      ['oml-empowerd', { repoUrl: 'https://github/oml-empowerd', issueUrl: 'https://github/oml-empowerd/issues', julesUrl: 'https://jules/oml-empowerd' }],
-    ])
-
-    const result = groupServices(services, repoMap)
-
-    expect(result).toHaveLength(1)
-    expect(result[0].baseName).toBe('oml-empowerd')
-    expect(result[0].main?.url).toBe('https://oml')
-    expect(result[0].test?.url).toBe('https://oml-test')
-  })
-
   it('sorts groups by base name', () => {
     const services: ServiceListItem[] = [
       { name: 'z-app', url: 'https://z', logUrl: 'https://logs/z' },

--- a/tests/service-grouping.test.ts
+++ b/tests/service-grouping.test.ts
@@ -47,6 +47,23 @@ describe('groupServices', () => {
     expect(result[0].main).toBeUndefined()
   })
 
+  it('matches services with repo names using prefix matching', () => {
+    const services: ServiceListItem[] = [
+      { name: 'oml', url: 'https://oml', logUrl: 'https://logs/oml' },
+      { name: 'oml-test', url: 'https://oml-test', logUrl: 'https://logs/oml-test' },
+    ]
+    const repoMap = new Map([
+      ['oml-empowerd', { repoUrl: 'https://github/oml-empowerd', issueUrl: 'https://github/oml-empowerd/issues', julesUrl: 'https://jules/oml-empowerd' }],
+    ])
+
+    const result = groupServices(services, repoMap)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].baseName).toBe('oml-empowerd')
+    expect(result[0].main?.url).toBe('https://oml')
+    expect(result[0].test?.url).toBe('https://oml-test')
+  })
+
   it('sorts groups by base name', () => {
     const services: ServiceListItem[] = [
       { name: 'z-app', url: 'https://z', logUrl: 'https://logs/z' },


### PR DESCRIPTION
アプリ一覧の表示基準を Cloud Run サービスから GitHub リポジトリに変更しました。これにより、デプロイ前のリポジトリもポータル上で確認できるようになります。あわせて UI の文言を「Applications」に統一し、関連するロジックとテストを更新しました。

Fixes #37

---
*PR created automatically by Jules for task [13680319977427051626](https://jules.google.com/task/13680319977427051626) started by @yananob*