### PR TITLE
GitHubリポジトリ取得ロジックの改善（プライベートリポジトリ対応）

### DIFF
--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -21,14 +21,15 @@ export async function getAllReposInfo(): Promise<Map<string, GitHubRepoInfo>> {
   const octokit = new Octokit({ auth: githubPat });
 
   try {
-    const repos = await octokit.paginate(octokit.rest.repos.listForOrg, {
-      org: githubOwner,
+    // 認証ユーザーがアクセス可能なすべてのリポジトリを取得（パブリック・プライベート両方）
+    const allRepos = await octokit.paginate(octokit.rest.repos.listForAuthenticatedUser, {
+      visibility: "all",
       per_page: 100,
-    }).catch(() =>
-      octokit.paginate(octokit.rest.repos.listForUser, {
-        username: githubOwner,
-        per_page: 100,
-      })
+    });
+
+    // 指定されたオーナー（ユーザーまたは組織）のリポジトリのみにフィルタリング
+    const repos = allRepos.filter(
+      (repo) => repo.owner.login.toLowerCase() === githubOwner.toLowerCase()
     );
 
     const repoMap = new Map<string, GitHubRepoInfo>();

--- a/tests/github-client.test.ts
+++ b/tests/github-client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getAllReposInfo } from '../src/lib/github-client'
+import { Octokit } from 'octokit'
+
+vi.mock('octokit', () => {
+  const Octokit = vi.fn()
+  Octokit.prototype.rest = {
+    repos: {
+      listForAuthenticatedUser: vi.fn(),
+    }
+  }
+  Octokit.prototype.paginate = vi.fn()
+  return { Octokit }
+})
+
+describe('getAllReposInfo', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv, GITHUB_OWNER: 'test-owner', GITHUB_PAT: 'test-token' }
+    vi.clearAllMocks()
+  })
+
+  it('fetches and filters repositories correctly', async () => {
+    const mockRepos = [
+      {
+        name: 'repo1',
+        owner: { login: 'test-owner' },
+        html_url: 'https://github.com/test-owner/repo1',
+        archived: false,
+      },
+      {
+        name: 'repo2',
+        owner: { login: 'other-owner' },
+        html_url: 'https://github.com/other-owner/repo2',
+        archived: false,
+      },
+      {
+        name: 'repo3',
+        owner: { login: 'test-owner' },
+        html_url: 'https://github.com/test-owner/repo3',
+        archived: true,
+      },
+    ]
+
+    const octokitInstance = new Octokit()
+    vi.mocked(octokitInstance.paginate).mockResolvedValue(mockRepos as any)
+
+    const result = await getAllReposInfo()
+
+    expect(result.size).toBe(1)
+    expect(result.has('repo1')).toBe(true)
+    expect(result.has('repo2')).toBe(false)
+    expect(result.has('repo3')).toBe(false) // Archived should be excluded
+
+    const repo1 = result.get('repo1')
+    expect(repo1?.repoUrl).toBe('https://github.com/test-owner/repo1')
+    expect(repo1?.issueUrl).toBe('https://github.com/test-owner/repo1/issues')
+    expect(repo1?.julesUrl).toContain('/test-owner/repo1/')
+  })
+
+  it('throws error if GITHUB_OWNER is not set', async () => {
+    delete process.env.GITHUB_OWNER
+    await expect(getAllReposInfo()).rejects.toThrow('GITHUB_OWNER is not set')
+  })
+})


### PR DESCRIPTION
GitHubリポジトリ取得ロジックを改善し、プライベートリポジトリも含めて取得・表示できるようにしました。これまでは公開リポジトリのみが取得対象となっていましたが、`listForAuthenticatedUser` を使用することで認証トークンがアクセス可能な全リポジトリを取得し、指定されたオーナーでフィルタリングする方式に変更しました。あわせてユニットテストを追加し、正常にフィルタリングされることを確認しています。

Fixes #39

---
*PR created automatically by Jules for task [4920587188162057110](https://jules.google.com/task/4920587188162057110) started by @yananob*