### PR TITLE
GitHubリンクの改善とマッチングロジックの修正

### DIFF
--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -78,45 +78,45 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
           <h3 className="text-base sm:text-lg font-bold text-slate-900 dark:text-slate-100 truncate mr-2" title={baseName}>
             {baseName}
           </h3>
-          <div className="flex gap-3 shrink-0">
+          <div className="flex gap-4 shrink-0">
             {repoUrl ? (
               <a
                 href={repoUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-slate-500 hover:text-blue-600 transition-colors"
+                className="text-slate-500 hover:text-blue-600 transition-colors p-1 -m-1"
                 title="Repository"
               >
-                <Github className="w-4 h-4 sm:w-5 h-5" />
+                <Github className="w-5 h-5 sm:w-6 h-6" />
               </a>
             ) : (
-              <Github className="w-4 h-4 sm:w-5 h-5 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
+              <Github className="w-5 h-5 sm:w-6 h-6 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
             )}
             {issueUrl ? (
               <a
                 href={issueUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-slate-500 hover:text-blue-600 transition-colors"
+                className="text-slate-500 hover:text-blue-600 transition-colors p-1 -m-1"
                 title="Issues"
               >
-                <MessageSquare className="w-4 h-4 sm:w-5 h-5" />
+                <MessageSquare className="w-5 h-5 sm:w-6 h-6" />
               </a>
             ) : (
-              <MessageSquare className="w-4 h-4 sm:w-5 h-5 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
+              <MessageSquare className="w-5 h-5 sm:w-6 h-6 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
             )}
             {julesUrl ? (
               <a
                 href={julesUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-slate-500 hover:text-blue-600 transition-colors"
+                className="text-slate-500 hover:text-blue-600 transition-colors p-1 -m-1"
                 title="Jules"
               >
-                <Zap className="w-4 h-4 sm:w-5 h-5" />
+                <Zap className="w-5 h-5 sm:w-6 h-6" />
               </a>
             ) : (
-              <Zap className="w-4 h-4 sm:w-5 h-5 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
+              <Zap className="w-5 h-5 sm:w-6 h-6 text-slate-200 dark:text-slate-800 cursor-not-allowed" />
             )}
           </div>
         </div>

--- a/src/lib/service-utils.ts
+++ b/src/lib/service-utils.ts
@@ -10,8 +10,9 @@ export function groupServices(services: ServiceListItem[], repoMap: Map<string, 
   const groupsMap = new Map<string, ServiceGroup>();
 
   // 1. GitHubリポジトリをベースに初期グループを作成
+  // マッチングを容易にするため、キーは小文字で保持する
   for (const [name, repoInfo] of repoMap.entries()) {
-    groupsMap.set(name, {
+    groupsMap.set(name.toLowerCase(), {
       baseName: name,
       repoUrl: repoInfo.repoUrl,
       issueUrl: repoInfo.issueUrl,
@@ -35,14 +36,16 @@ export function groupServices(services: ServiceListItem[], repoMap: Map<string, 
       type = "event";
     }
 
-    let group = groupsMap.get(baseName);
+    // Cloud Runサービス名は小文字なので、小文字でマッチングを行う
+    const lookupKey = baseName.toLowerCase();
+    let group = groupsMap.get(lookupKey);
 
     if (!group) {
       // リポジトリが見つからない場合でもグループを作成（Cloud Runのみ存在する場合）
       group = {
         baseName,
       };
-      groupsMap.set(baseName, group);
+      groupsMap.set(lookupKey, group);
     }
 
     group[type] = {

--- a/tests/service-grouping.test.ts
+++ b/tests/service-grouping.test.ts
@@ -58,4 +58,24 @@ describe('groupServices', () => {
     expect(result[0].baseName).toBe('a-app')
     expect(result[1].baseName).toBe('z-app')
   })
+
+  it('matches repository names and service names case-insensitively', () => {
+    const services: ServiceListItem[] = [
+      { name: 'my-project', url: 'https://my-project', logUrl: 'https://logs/my-project' },
+      { name: 'my-project-test', url: 'https://my-project-test', logUrl: 'https://logs/my-project-test' },
+    ]
+
+    const repoMap = new Map([
+      ['My-Project', { repoUrl: 'https://github/My-Project', issueUrl: 'https://github/My-Project/issues', julesUrl: 'https://jules/My-Project' }],
+    ])
+
+    const result = groupServices(services, repoMap)
+
+    expect(result).toHaveLength(1)
+    const group = result[0]
+    expect(group.baseName).toBe('My-Project') // Should preserve original repo casing for display
+    expect(group.repoUrl).toBe('https://github/My-Project')
+    expect(group.main?.url).toBe('https://my-project')
+    expect(group.test?.url).toBe('https://my-project-test')
+  })
 })


### PR DESCRIPTION
GitHubへのリンクアイコンが小さく押しにくい問題と、一部のリポジトリでリンクが表示されない問題を修正しました。

1. **UIの改善**:
   - `ServiceCard`内のGitHub、Issues、Julesアイコンのサイズを `w-4 h-4` から `w-5 h-5` (デスクトップでは `w-6 h-6`) に拡大しました。
   - `p-1 -m-1` を適用することで、見た目のレイアウトを変えずにクリック可能な領域（ヒットエリア）を拡大しました。
   - アイコン間の間隔を `gap-3` から `gap-4` に広げました。

2. **ロジックの修正**:
   - Cloud Runのサービス名は常に小文字ですが、GitHubのリポジトリ名は検索時に大文字が含まれることがあります。
   - `groupServices` 関数において、内部的なマップのキーを小文字に統一することで、大文字小文字に関わらず正しくリポジトリとサービスが紐付くように修正しました。
   - 表示上のリポジトリ名（`baseName`）は元のケースを保持します。

3. **テストと検証**:
   - `tests/service-grouping.test.ts` に大文字小文字混在のリポジトリ名のマッチングを検証するテストケースを追加しました。
   - 全てのユニットテストがパスすることを確認しました。
   - Playwrightを使用して、モバイル（iPhone SEサイズ）およびデスクトップでの表示崩れがないこと、およびモックデータを用いたリンクの表示を確認しました。

Fixes #43

---
*PR created automatically by Jules for task [8748136684911341779](https://jules.google.com/task/8748136684911341779) started by @yananob*