### PR TITLE
キャッシュ機能とリポジトリ非表示機能の追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Search, Loader2, RefreshCw, AlertCircle, X } from "lucide-react";
+import { Search, Loader2, RefreshCw, AlertCircle, X, Eye, EyeOff } from "lucide-react";
 import { ServiceCard } from "@/components/ServiceCard";
 import { cn } from "@/lib/utils";
 import { ServiceGroup } from "@/lib/types";
@@ -12,17 +12,42 @@ export default function Dashboard() {
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+  const [showHidden, setShowHidden] = useState(false);
 
-  const fetchServices = async () => {
+  const CACHE_KEY = "my-cfapps-portal-cache";
+  const CACHE_TIME_KEY = "my-cfapps-portal-cache-time";
+  const HIDDEN_KEY = "my-cfapps-portal-hidden";
+
+  const fetchServices = async (useCache = true) => {
     setLoading(true);
     setError(null);
+
+    // キャッシュの読み込み
+    if (useCache) {
+      const cachedData = localStorage.getItem(CACHE_KEY);
+      const cachedTime = localStorage.getItem(CACHE_TIME_KEY);
+      if (cachedData && cachedTime) {
+        setServiceGroups(JSON.parse(cachedData));
+        setLastUpdated(new Date(parseInt(cachedTime)));
+        setLoading(false);
+        // キャッシュがある場合はバックグラウンドで更新するなどの検討もできるが、
+        // ユーザーの要望「最新化にはリロードボタン押下」に従い、ここでは終了する
+        return;
+      }
+    }
+
     try {
       const response = await fetch("/api/services");
       const data = await response.json();
 
       if (response.ok) {
         setServiceGroups(data);
-        setLastUpdated(new Date());
+        const now = new Date();
+        setLastUpdated(now);
+        // キャッシュの保存
+        localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+        localStorage.setItem(CACHE_TIME_KEY, now.getTime().toString());
       } else {
         setError(data.error || "Failed to fetch services");
       }
@@ -35,14 +60,46 @@ export default function Dashboard() {
   };
 
   useEffect(() => {
-    fetchServices();
+    fetchServices(true);
+    // 非表示リストの読み込み
+    const savedHidden = localStorage.getItem(HIDDEN_KEY);
+    if (savedHidden) {
+      try {
+        setHiddenIds(new Set(JSON.parse(savedHidden)));
+      } catch (e) {
+        console.error("Failed to parse hidden IDs:", e);
+      }
+    }
   }, []);
 
+  const toggleHide = (baseName: string) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(baseName)) {
+        next.delete(baseName);
+      } else {
+        next.add(baseName);
+      }
+      localStorage.setItem(HIDDEN_KEY, JSON.stringify(Array.from(next)));
+      return next;
+    });
+  };
+
   const filteredGroups = useMemo(() => {
-    return serviceGroups.filter((group) =>
-      group.baseName.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-  }, [serviceGroups, searchQuery]);
+    return serviceGroups
+      .filter((group) =>
+        group.baseName.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+      .filter((group) => showHidden || !hiddenIds.has(group.baseName))
+      .sort((a, b) => {
+        // 非表示のものを下に持ってくる
+        const aHidden = hiddenIds.has(a.baseName);
+        const bHidden = hiddenIds.has(b.baseName);
+        if (aHidden && !bHidden) return 1;
+        if (!aHidden && bHidden) return -1;
+        return 0;
+      });
+  }, [serviceGroups, searchQuery, hiddenIds, showHidden]);
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl">
@@ -82,14 +139,32 @@ export default function Dashboard() {
               </button>
             )}
           </div>
-          <button
-            onClick={fetchServices}
-            disabled={loading}
-            className="p-2 text-slate-600 hover:text-blue-600 dark:text-slate-400 dark:hover:text-blue-400 disabled:opacity-50 transition-colors"
-            title="Refresh list"
-          >
-            <RefreshCw className={cn("w-5 h-5", loading && "animate-spin")} />
-          </button>
+          <div className="flex items-center gap-1 border-l border-slate-200 dark:border-slate-800 ml-2 pl-2">
+            <button
+              onClick={() => setShowHidden(!showHidden)}
+              className={cn(
+                "p-2 transition-colors rounded-md",
+                showHidden
+                  ? "text-blue-600 bg-blue-50 dark:bg-blue-900/20"
+                  : "text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+              )}
+              title={showHidden ? "非表示アイテムを隠す" : "非表示アイテムを表示"}
+            >
+              {showHidden ? (
+                <Eye className="w-5 h-5" />
+              ) : (
+                <EyeOff className="w-5 h-5" />
+              )}
+            </button>
+            <button
+              onClick={() => fetchServices(false)}
+              disabled={loading}
+              className="p-2 text-slate-600 hover:text-blue-600 dark:text-slate-400 dark:hover:text-blue-400 disabled:opacity-50 transition-colors"
+              title="Refresh list"
+            >
+              <RefreshCw className={cn("w-5 h-5", loading && "animate-spin")} />
+            </button>
+          </div>
         </div>
       </header>
 
@@ -134,6 +209,8 @@ export default function Dashboard() {
                   repoUrl={group.repoUrl}
                   issueUrl={group.issueUrl}
                   julesUrl={group.julesUrl}
+                  isHidden={hiddenIds.has(group.baseName)}
+                  onToggleHide={toggleHide}
                 />
               ))}
             </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Github, MessageSquare, ListTodo, Globe, ExternalLink, Zap } from "lucide-react";
+import { Github, MessageSquare, ListTodo, Globe, ExternalLink, Zap, Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ServiceInstance } from "@/lib/types";
 
@@ -12,6 +12,8 @@ interface ServiceCardProps {
   repoUrl?: string;
   issueUrl?: string;
   julesUrl?: string;
+  isHidden?: boolean;
+  onToggleHide?: (baseName: string) => void;
 }
 
 const InstanceButtons: React.FC<{
@@ -69,15 +71,35 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
   repoUrl,
   issueUrl,
   julesUrl,
+  isHidden = false,
+  onToggleHide,
 }) => {
   return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg shadow-sm hover:shadow-md transition-all overflow-hidden">
+    <div className={cn(
+      "bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg shadow-sm hover:shadow-md transition-all overflow-hidden",
+      isHidden && "opacity-60 grayscale-[0.5]"
+    )}>
       <div className="p-3 sm:p-4">
         {/* Name and Repo Links */}
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-base sm:text-lg font-bold text-slate-900 dark:text-slate-100 truncate mr-2" title={baseName}>
-            {baseName}
-          </h3>
+          <div className="flex items-center gap-2 min-w-0">
+            <h3 className="text-base sm:text-lg font-bold text-slate-900 dark:text-slate-100 truncate" title={baseName}>
+              {baseName}
+            </h3>
+            {onToggleHide && (
+              <button
+                onClick={() => onToggleHide(baseName)}
+                className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors shrink-0"
+                title={isHidden ? "表示する" : "非表示にする"}
+              >
+                {isHidden ? (
+                  <EyeOff className="w-4 h-4" />
+                ) : (
+                  <Eye className="w-4 h-4" />
+                )}
+              </button>
+            )}
+          </div>
           <div className="flex gap-4 shrink-0">
             {repoUrl ? (
               <a


### PR DESCRIPTION
起動高速化のためのキャッシュ機能と、特定のリポジトリを非表示にする機能を実装しました。

### 変更内容

1.  **起動の高速化（キャッシュ機能）**
    - `localStorage` を使用して API から取得したサービス一覧をキャッシュするようにしました。
    - ページを開いた際は即座にキャッシュを表示するため、体感速度が大幅に向上します。
    - 「最新化にはリロードボタン押下が必須」という要望に基づき、リロードボタンを押した時のみ API を叩いてキャッシュを更新する仕様にしました。

2.  **リポジトリの非表示/表示切り替え**
    - 各サービスカードのタイトル横に `Eye` アイコンを追加しました。これをクリックすることで、そのリポジトリを非表示リストに追加できます。
    - 非表示リストは `localStorage` に保存され、ブラウザを閉じても維持されます。
    - ヘッダー右側の検索バー横に、全体の表示/非表示を切り替えるボタンを追加しました。
        - デフォルト（非表示アイテムを隠す状態）: 非表示に設定したリポジトリは一覧から消えます。
        - 非表示アイテムを表示する状態: 非表示に設定したリポジトリがリストの末尾に、グレーアウトされた状態で表示されます。ここから再度表示状態に戻すことも可能です。

### 検証内容
- `vitest` による既存のユニットテストのパスを確認しました。
- `Playwright` を使用して、キャッシュの動作、非表示/表示の切り替え、永続化の挙動を視覚的に確認しました。

Fixes #45

---
*PR created automatically by Jules for task [7630587039815793950](https://jules.google.com/task/7630587039815793950) started by @yananob*