### PR TITLE
HTTPおよびEventサービスのCloud Runデプロイ設定を修正

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -51,8 +51,8 @@ jobs:
           service: ${{ needs.prepare.outputs.http_service_name }}
           region: ${{ secrets.GCP_REGION }}
           source: .
-          # flags: '--clear-base-image' --memory=256Mi
-          flags: --memory=256Mi
+          # flags: '--clear-base-image' --allow-unauthenticated --memory=256Mi
+          flags: --allow-unauthenticated --memory=256Mi
           env_vars: |-
             GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
             GCP_REGION=${{ secrets.GCP_REGION }}
@@ -85,7 +85,7 @@ jobs:
           service: ${{ needs.prepare.outputs.event_service_name }}
           region: ${{ secrets.GCP_REGION }}
           source: .
-          flags: --memory=256Mi
+          flags: --no-allow-unauthenticated --memory=256Mi
           env_vars: |-
             GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
             GCP_REGION=${{ secrets.GCP_REGION }}

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -59,7 +59,7 @@ jobs:
           service: ${{ needs.prepare.outputs.http_service_name }}
           region: ${{ secrets.GCP_REGION }}
           source: .
-          flags: --memory=256Mi
+          flags: --allow-unauthenticated --memory=256Mi
           env_vars: |-
             GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
             GCP_REGION=${{ secrets.GCP_REGION }}
@@ -92,7 +92,7 @@ jobs:
   #         service: ${{ needs.prepare.outputs.event_service_name }}
   #         region: ${{ secrets.GCP_REGION }}
   #         source: .
-  #         flags: --memory=256Mi
+  #         flags: --no-allow-unauthenticated --memory=256Mi
   #         env_vars: |-
   #           GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
   #           GCP_REGION=${{ secrets.GCP_REGION }}


### PR DESCRIPTION
HTTPサービス (deploy-http) には --allow-unauthenticated フラグ、Eventarcトリガーで起動されるEventサービス (deploy-event) には --no-allow-unauthenticated フラグを deploy-production.yaml および deploy-test.yaml の flags に設定しました。これにより、バックエンドイベント処理サービスへの安全なアクセス制限が保証されます。

---
*PR created automatically by Jules for task [17602993754263547309](https://jules.google.com/task/17602993754263547309) started by @yananob*