### PR TITLE
Pub/SubのPOSTリクエストによる405エラーの修正

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl;
+
+  // Root path (/) receives POST requests from Pub/Sub / Eventarc
+  // Rewrite them to /api/cleanup with existing query parameters preserved
+  if (request.method === "POST" && url.pathname === "/") {
+    url.pathname = "/api/cleanup";
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+}
+
+// Apply middleware only to the root path to minimize overhead
+export const config = {
+  matcher: "/",
+};

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { middleware } from "@/middleware";
+import { NextRequest, NextResponse } from "next/server";
+
+// Mock NextResponse.rewrite and NextResponse.next to track calls and return mock response objects
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    NextResponse: {
+      ...original.NextResponse,
+      rewrite: vi.fn((url) => ({ status: "rewrite", url: url.toString() })),
+      next: vi.fn(() => ({ status: "next" })),
+    },
+  };
+});
+
+describe("Middleware", () => {
+  const createMockRequest = (method: string, urlStr: string) => {
+    const url = new URL(urlStr);
+    return {
+      method,
+      nextUrl: url,
+    } as unknown as NextRequest;
+  };
+
+  it("should rewrite POST request on root (/) to /api/cleanup", () => {
+    const request = createMockRequest("POST", "https://example.com/");
+    const result = middleware(request);
+
+    expect(NextResponse.rewrite).toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "rewrite",
+      url: "https://example.com/api/cleanup",
+    });
+  });
+
+  it("should preserve query parameters when rewriting", () => {
+    const request = createMockRequest("POST", "https://example.com/?dryRun=false&foo=bar");
+    const result = middleware(request);
+
+    expect(NextResponse.rewrite).toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "rewrite",
+      url: "https://example.com/api/cleanup?dryRun=false&foo=bar",
+    });
+  });
+
+  it("should pass through GET request on root (/) normally", () => {
+    vi.mocked(NextResponse.next).mockClear();
+    const request = createMockRequest("GET", "https://example.com/");
+    const result = middleware(request);
+
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(result).toEqual({ status: "next" });
+  });
+
+  it("should pass through POST request on other paths normally", () => {
+    vi.mocked(NextResponse.next).mockClear();
+    const request = createMockRequest("POST", "https://example.com/api/services");
+    const result = middleware(request);
+
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(result).toEqual({ status: "next" });
+  });
+});


### PR DESCRIPTION
GCP Pub/Sub や Eventarc などのプッシュ通知が、デフォルトでアプリケーションのルートパス (/) に対し POST リクエストを送信し、Next.js 側で 405 Method Not Allowed エラーが返されてしまう不具合を修正しました。

Next.js の Middleware (src/middleware.ts) を実装し、ルートへの POST リクエストのみを内部的にクリーンアップ処理エンドポイント (/api/cleanup) へリライト (Rewrite) することで、正しくメッセージを受け取りイベント処理が実行できるようにしました。
また、該当ミドルウェアの挙動をカバーするユニットテストを追加し、テストが正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [12207558471516987974](https://jules.google.com/task/12207558471516987974) started by @yananob*